### PR TITLE
Remove proxy from build configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,8 +66,7 @@
           },
           "configurations": {
             "production": {
-              "browserTarget": "Frontend:build:production",
-              "proxyConfig": "proxy.conf.json"
+              "browserTarget": "Frontend:build:production"
             }
           }
         },


### PR DESCRIPTION
# Issue: Registration returns HTTP 301

## Summary

When trying to register, the server returns an HTTP 301 code.

## Proposed Solution

Removal of the proxy during development made it possible to perform the registration request.
Test in production environment to confirm solution.